### PR TITLE
Update to current OS X SDK.

### DIFF
--- a/PDFFonts.xcodeproj/project.pbxproj
+++ b/PDFFonts.xcodeproj/project.pbxproj
@@ -177,6 +177,7 @@
 				GCC_OPTIMIZATION_LEVEL = 0;
 				INSTALL_PATH = /usr/local/bin;
 				PRODUCT_NAME = PDFFonts;
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
@@ -186,6 +187,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				INSTALL_PATH = /usr/local/bin;
 				PRODUCT_NAME = PDFFonts;
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Hi,

this is a pretty basic one - but since the 10.6 Base SDK has gone missing for most of the people let's just use the latest OS X SDK as Base - works fine for 10.7 and 10.8 and most certainly for the next releases to come.

Would be great if you could merge those changes in.

Thanks,
Mat
